### PR TITLE
remove checkpoint call from all scripts

### DIFF
--- a/1.DataInclusion/Scripts/A.getInclusion.R
+++ b/1.DataInclusion/Scripts/A.getInclusion.R
@@ -10,9 +10,6 @@
 # This script will perform our inclusion criteria on all datasets included
 # in curatedOvarianData and a dataset from the Mayo Clinic
 
-suppressMessages(library(checkpoint))
-suppressMessages(checkpoint('2016-03-01', checkpointLocation = "."))
-
 ####################################
 # Load Libraries
 ####################################

--- a/1.DataInclusion/Scripts/B.getGenes.R
+++ b/1.DataInclusion/Scripts/B.getGenes.R
@@ -7,9 +7,6 @@
 # Output gene lists (common genes and MAD genes) and
 # Overlapping Genes Venn Diagram: Supplemental Figure 1
 
-suppressMessages(library(checkpoint))
-suppressMessages(checkpoint('2016-03-01', checkpointLocation = "."))
-
 args <- commandArgs(trailingOnly = T)
 # args <- c("TCGA_eset", "mayo.eset", "GSE32062.GPL6480_eset", "GSE9891_eset", "GSE26712_eset", "aaces.eset")
 # args <- c("TCGA_eset", "aaces.eset")

--- a/2.Clustering_DiffExprs/Scripts/A.run_kmeans_SAM.R
+++ b/2.Clustering_DiffExprs/Scripts/A.run_kmeans_SAM.R
@@ -9,9 +9,6 @@
 # across k and across datasets, it will output cluster membership files and 
 # correlations
 
-suppressMessages(library(checkpoint))
-suppressMessages(checkpoint("2016-03-01", checkpointLocation = "."))
-
 args <- commandArgs(trailingOnly = TRUE)
 
 # args <- c(2, 4, 20, 123, TRUE, FALSE, "commongenes", "TCGA_eset", "mayo.eset",

--- a/2.Clustering_DiffExprs/Scripts/B.CorrelationMatrix.R
+++ b/2.Clustering_DiffExprs/Scripts/B.CorrelationMatrix.R
@@ -7,9 +7,6 @@
 # This script will input a series of datasets and output sample by sample 
 # correlation matrix heatmaps
 
-suppressMessages(library(checkpoint))
-suppressMessages(checkpoint('2016-03-01', checkpointLocation = "."))
-
 args <- commandArgs(trailingOnly=TRUE)
 # args <- c(2, 4, 123, "Figures/CorrelationMatrix/", "TCGA_eset", "mayo.eset", "GSE32062.GPL6480_eset", "GSE9891_eset", "GSE26712_eset", "aaces.eset")
 ###########################################

--- a/2.Clustering_DiffExprs/Scripts/C.KMeansBarCharts.R
+++ b/2.Clustering_DiffExprs/Scripts/C.KMeansBarCharts.R
@@ -6,9 +6,6 @@
 # ~~~~~~~~~~~~~~~~~~~~~
 # This script will input a series of datasets and output bar charts
 
-suppressMessages(library(checkpoint))
-suppressMessages(checkpoint('2016-03-01', checkpointLocation = "."))
-
 args <- commandArgs(trailingOnly=TRUE)
 # args <- c("2", "4", "TCGA_eset", "mayo.eset", "GSE32062.GPL6480_eset", "GSE9891_eset", "GSE26712_eset")
 

--- a/2.Clustering_DiffExprs/Scripts/D.NMF.R
+++ b/2.Clustering_DiffExprs/Scripts/D.NMF.R
@@ -8,9 +8,6 @@
 # This script will input a series of datasets and perform Non-negative Matrix
 # Factorization (NMF)
 
-suppressMessages(library(checkpoint))
-suppressMessages(checkpoint('2016-03-01', checkpointLocation = "."))
-
 args <- commandArgs(trailingOnly = TRUE)
 # args <- c(2, 4, 100, 123, "TCGA_eset", "mayo.eset", "GSE32062.GPL6480_eset",
 #          "GSE9891_eset", "GSE26712_eset", "aaces.eset")

--- a/2.Clustering_DiffExprs/Scripts/E.kmeans_v_nmf.R
+++ b/2.Clustering_DiffExprs/Scripts/E.kmeans_v_nmf.R
@@ -7,9 +7,6 @@
 # ~~~~~~~~~~~~~~~~~~~~~
 # This script will compare clusters identified by k-means and NMF
 
-suppressMessages(library(checkpoint))
-suppressMessages(checkpoint('2016-03-01', checkpointLocation = "."))
-
 args <- commandArgs(trailingOnly=TRUE)
 # args <- c("TCGA_eset", "mayo.eset", "GSE32062.GPL6480_eset",
 # "GSE9891_eset", "aaces.eset")

--- a/2.Clustering_DiffExprs/Scripts/F.clusterMembership.R
+++ b/2.Clustering_DiffExprs/Scripts/F.clusterMembership.R
@@ -6,9 +6,6 @@
 # ~~~~~~~~~~~~~~~~~~~~~
 # This script will output a data frame of cluster membership for all clustering events
 
-suppressMessages(library(checkpoint))
-suppressMessages(checkpoint('2016-03-01', checkpointLocation = "."))
-
 args <- commandArgs(trailingOnly=TRUE)
 # args <- c("TCGA_eset", "mayo.eset", "GSE32062.GPL6480_eset", "GSE9891_eset", "GSE26712_eset", "aaces.eset")
 

--- a/2.Clustering_DiffExprs/Scripts/G.Dataset_concordance.R
+++ b/2.Clustering_DiffExprs/Scripts/G.Dataset_concordance.R
@@ -9,9 +9,6 @@
 # identified in the 2008 Clin Cancer Research Paper, and the original Konecny 
 # subtypes identified in the 2014 JNCI paper
 
-suppressMessages(library(checkpoint))
-suppressMessages(checkpoint('2016-03-01', checkpointLocation = "."))
-
 library(curatedOvarianData)
 
 ############################################

--- a/2.Clustering_DiffExprs/Scripts/H.TCGA_LMP_TothillPrediction.R
+++ b/2.Clustering_DiffExprs/Scripts/H.TCGA_LMP_TothillPrediction.R
@@ -8,9 +8,6 @@
 # except without removing LMP samples to contrast our biological filtering
 # findings
 
-suppressMessages(library(checkpoint))
-suppressMessages(checkpoint('2016-03-01', checkpointLocation = "."))
-
 set.seed(123)
 
 ################################

--- a/3.Fit/Scripts/A.GoodnessFit.R
+++ b/3.Fit/Scripts/A.GoodnessFit.R
@@ -6,9 +6,6 @@
 # ~~~~~~~~~~~~~~~~~~~~~
 # This script will output the AIC, BIC, and Silhouette Width plots
 
-suppressMessages(library(checkpoint))
-suppressMessages(checkpoint('2016-03-01', checkpointLocation = "."))
-
 args <- commandArgs(trailingOnly=TRUE)
 # args <- c(2, 8, 20, 20, 123, "TCGA_eset", "Mayo", "GSE32062.GPL6480_eset", "GSE9891_eset")
 ############################################

--- a/4.Survival/Scripts/A.Survival.R
+++ b/4.Survival/Scripts/A.Survival.R
@@ -6,9 +6,6 @@
 # ~~~~~~~~~~~~~~~~~~~~~
 # This script will output kaplan-meier curves and survival assessments for all input datasets
 
-suppressMessages(library(checkpoint))
-suppressMessages(checkpoint('2016-03-01', checkpointLocation = "."))
-
 args <- commandArgs(trailingOnly=TRUE)
 
 # args <- c("TCGA_eset", "Mayo", "GSE32062.GPL6480_eset", "GSE9891_eset")

--- a/4.Survival/Scripts/B.Summarize_Survival.R
+++ b/4.Survival/Scripts/B.Summarize_Survival.R
@@ -7,9 +7,6 @@
 # This script will summarize all of the multi-variate and univariate survival analyses
 ############################################
 
-suppressMessages(library(checkpoint))
-suppressMessages(checkpoint('2016-03-01', checkpointLocation = "."))
-
 args <- commandArgs(trailingOnly=TRUE)
 # args <- c("TCGA_eset", "Mayo", "GSE32062.GPL6480_eset", "GSE9891_eset")
 

--- a/5.Pathway/Scripts/A.GeneEnrichment.R
+++ b/5.Pathway/Scripts/A.GeneEnrichment.R
@@ -7,9 +7,6 @@
 # The script will output a table of the differentially expressed genes for each cluster, 
 # both positively and negatively regulated
 
-suppressMessages(library(checkpoint))
-suppressMessages(checkpoint('2016-03-01', checkpointLocation = "."))
-
 args <- commandArgs(trailingOnly=TRUE)
 #args <- c("TCGA_eset", "Mayo", "GSE32062.GPL6480_eset", "GSE9891_eset")
 

--- a/6.Immune_Infiltrate/Scripts/A.ESTIMATE.R
+++ b/6.Immune_Infiltrate/Scripts/A.ESTIMATE.R
@@ -17,9 +17,6 @@
 # Box plots by subtype for ESTIMATE score and tumor purity
 # Scatter plots by subtype for comparing Stromal and Immune score
 
-suppressMessages(library(checkpoint))
-suppressMessages(checkpoint('2016-03-01', checkpointLocation = "."))
-
 args <- commandArgs(trailingOnly = TRUE)
 
 # args <- c("TCGA_eset", "mayo.eset", "GSE32062.GPL6480_eset", "GSE9891_eset")

--- a/6.Immune_Infiltrate/Scripts/B.ssGSEA.R
+++ b/6.Immune_Infiltrate/Scripts/B.ssGSEA.R
@@ -19,9 +19,6 @@
 # Tables with ssGSEA scores for each cell class
 # Box plots by subtype for ssGSEA scores
 
-suppressMessages(library(checkpoint))
-suppressMessages(checkpoint('2016-03-01', checkpointLocation = "."))
-
 args <- commandArgs(trailingOnly = TRUE)
 
 # args <- c("TCGA_eset", "mayo.eset", "GSE32062.GPL6480_eset", "GSE9891_eset")

--- a/6.Immune_Infiltrate/Scripts/C.MCPcounter.R
+++ b/6.Immune_Infiltrate/Scripts/C.MCPcounter.R
@@ -17,9 +17,6 @@
 # Tables with MCPcounter results for each sample
 # Box plots by subtype for results
 
-suppressMessages(library(checkpoint))
-suppressMessages(checkpoint('2016-03-01', checkpointLocation = "."))
-
 ############################################
 # Load Libraries
 ############################################


### PR DESCRIPTION
The only changes are to remove:

```
suppressMessages(library(checkpoint))
suppressMessages(checkpoint('2016-03-01', checkpointLocation = "."))
```

from all scripts its included in. Not sure why some scripts are showing larger diffs
