### PR TITLE
Aaces data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 Rplots.pdf
 .Rhistory
 .checkpoint
+aaces.eset.RData
+aaces_expression.tsv

--- a/1.DataInclusion/Scripts/Functions/LoadOVCA_Data.R
+++ b/1.DataInclusion/Scripts/Functions/LoadOVCA_Data.R
@@ -23,6 +23,7 @@ LoadOVCA_Data <- function(datasets,
                           madgenes_dir = "1.DataInclusion/Data/Genes/GlobalMAD_genelist.csv",
                           genelist_subset = "commongenes",
                           mayo_exprs_file = "1.DataInclusion/Data/Mayo/MayoEset.Rda",
+                          aaces_exprs_file = "1.DataInclusion/Data/Aaces/aaces.eset.RData",
                           aaces_path = "aaces_expression.tsv",
                           shuffle = FALSE,
                           zscore = FALSE) {
@@ -85,11 +86,11 @@ LoadOVCA_Data <- function(datasets,
       cat("Loading", eset_exprs, "...\n")
       mayo.eset <- get(load(mayo_exprs_file))
       dta <- exprs(mayo.eset)
+      # neither is AACES
     } else if (grepl("aaces", eset_exprs)) {
       cat("Loading", eset_exprs, "...\n")
-      # AACES eset
-      dta <- read.table(aaces_path, sep = "\t", row.names = 1,
-                        header = TRUE)
+      aaces.eset <- get(load(aaces_exprs_file))
+      dta <- exprs(aaces.eset)
     } else {
       stop("Dataset does not exist in curatedOvarianData")
     }


### PR DESCRIPTION
The following pull request adds, fixes, and/or modifies:

1. Created AACES directory in DataInclusion/Data as for Mayo.
2. Added aaces_expression.tsv with all 158 samples to AACES directory.
3. Added the R workspace file aaces.eset.RData to AACES directory.  The file contains the ExpressionSet object called aaces.eset
4. Updated LoadOVCA_Data.R to use the aaces.eset ExpressionSet object as the source for expression values.  This method is preferred to read.delim especially when phenoData is added to the aaces.exprs. 
