### PR TITLE
Adding Nanostring module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Rplots.pdf
 .checkpoint
 aaces.eset.RData
 aaces_expression.tsv
+7.Nanostring/data/*

--- a/7.Nanostring/README.md
+++ b/7.Nanostring/README.md
@@ -96,7 +96,8 @@ For high confident genesets use Tier 1A but at the cost of smaller sets.
 
 ### Overrepresented pathways
 
-The gene stores the top 15 enriched gene ontology (GO) biological process terms against correlated genesets for all classifier genes.
+The table stores the top 15 enriched gene ontology (GO) biological process terms against correlated genesets for all classifier genes.
+We use `Tier 1B` genesets as input.
 A description of the columns:
 
 1. `classifier_gene` - The gene used in the nanostring subtype classifier

--- a/7.Nanostring/README.md
+++ b/7.Nanostring/README.md
@@ -11,28 +11,21 @@ We use [curatedOvarianData](https://bioconductor.org/packages/release/data/exper
 
 ## Procedure
 
+### Part I
+
 We take the 59 nanostring genes and consider their gene expression vectors across the four datasets independently.
 We then take pairwise Pearson correlations of each of these 59 genes against **all** other genes for each dataset.
 Lastly, we consider the genes in the top 5% and top 1% of these correlations for all 59 genes for each dataset.
-The useful output is a long data frame (`results/all_threshold_classifier_gene_correlations.tsv`) that stores the highest correlated genes against the nanostring classifier genes.
+A useful output is the long data frame (`results/all_threshold_classifier_gene_correlations.tsv`), which stores the highest correlated genes against the nanostring classifier genes.
 
-In addition, we output geneset files (`.gmt` format) under 4 different tiers of confidence.
+### Part II
+
+In addition, we output geneset files ([`.gmt` format](https://software.broadinstitute.org/cancer/software/gsea/wiki/index.php/Data_formats)) under 4 different tiers of confidence (see below).
 The file is located in `results/correlated_hgsc_classifier_genes.gmt`.
-The format of each line in this tab separated file is [classifier gene and confidence tier, correlated geneset (1, 2, ..., n)].
+The format of each line in this tab separated file is: [classifier gene and confidence tier, correlated geneset (1, 2, ..., n)].
 The first gene in the correlated geneset is the classifier gene itself.
 
-| Confidence Tier | Description |
-| :-------------: | :---------- |
-| Tier 1A | Genes in 99% threshold correlations for all 4 datasets |
-| Tier 1B | Genes in 99% threshold correlations for all 3 datasets measured in (allows for a single dataset with missing measurements) |
-| Tier 2A | Genes in 95% threshold correlations for all 4 datasets |
-| Tier 2B | Genes in 95% threshold correlations for all 3 datasets measured in (allows for a single dataset with missing measurements) |
-| Tier 3 | Genes in 95% threshold correlations for 3/4 datasets (allows for a single dataset to not have correlation) |
-| Tier 4 | Genes in 95% threshold correlations for 2/4 datasets (allows for two datasets to not have correlations) |
-
-The tier system is built into the single `.gmt`.
-For high confident genesets use Tier 1A but at the cost of smaller sets.
-All correlations at the 95% or 99% percentile in at least 1 dataset are given in `results/all_threshold_classifier_gene_correlations`.
+### Part III
 
 We then run a geneset overrepresentation analysis (ORA) using `Tier 1B` genes using all unique genes measured in the 4 datasets as background.
 We use [WebGestalt](https://doi.org/10.1093/nar/gkx356 "WebGestalt 2017: a more comprehensive, powerful, flexible and interactive gene set enrichment analysis toolkit") for ORA.
@@ -87,9 +80,21 @@ This happens when a significant gene by gene correlation exists in a different n
 ### Gene set file
 
 This file is compiled into a `.gmt` file with confidence tiers.
-See above for more details on tiers.
+The confidence tiers include
 
-### Overrepresented Pathways
+| Confidence Tier | Description |
+| :-------------: | :---------- |
+| Tier 1A | Genes in 99% threshold correlations for all 4 datasets |
+| Tier 1B | Genes in 99% threshold correlations for all 3 datasets measured in (allows for a single dataset with missing measurements) |
+| Tier 2A | Genes in 95% threshold correlations for all 4 datasets |
+| Tier 2B | Genes in 95% threshold correlations for all 3 datasets measured in (allows for a single dataset with missing measurements) |
+| Tier 3 | Genes in 95% threshold correlations for 3/4 datasets (allows for a single dataset to not have correlation) |
+| Tier 4 | Genes in 95% threshold correlations for 2/4 datasets (allows for two datasets to not have correlations) |
+
+The tier system is built into the single `.gmt`.
+For high confident genesets use Tier 1A but at the cost of smaller sets.
+
+### Overrepresented pathways
 
 The gene stores the top 15 enriched gene ontology (GO) biological process terms against correlated genesets for all classifier genes.
 A description of the columns:

--- a/7.Nanostring/README.md
+++ b/7.Nanostring/README.md
@@ -1,6 +1,6 @@
 # Gene Expression Correlations with Nanostring Subtype Classifier
 
-**Gregory Way and Casey Greene, 2018**
+**Gregory Way, Casey Greene, and Jennifer Doherty 2018**
 
 Previous research identified a sparse classifier of few genes that can classify High Grade Serous Ovarian Cancer (HGSC) subtypes.
 This classifier (Lasso) was selected to induce sparsity in the solutions so that the identified genes can be placed on a [nanostring](https://www.nanostring.com/) panel.
@@ -12,7 +12,7 @@ We use [curatedOvarianData](https://bioconductor.org/packages/release/data/exper
 ## Procedure
 
 We take the 29 nanostring genes and consider their gene expression vectors across the four datasets independently.
-We then take pairwise correlations of each of these 29 genes against **all** other genes for each dataset.
+We then take pairwise Pearson correlations of each of these 29 genes against **all** other genes for each dataset.
 Lastly, we consider the genes in the top 5% and top 1% of these correlations for all 29 genes for each dataset.
 The final output is a long data frame (`results/all_threshold_classifier_gene_correlations.tsv`) that stores the highest correlated genes against the nanostring classifier genes.
 

--- a/7.Nanostring/README.md
+++ b/7.Nanostring/README.md
@@ -34,6 +34,10 @@ The tier system is built into the single `.gmt`.
 For high confident genesets use Tier 1A but at the cost of smaller sets.
 All correlations at the 95% or 99% percentile in at least 1 dataset are given in `results/all_threshold_classifier_gene_correlations`.
 
+We then run a geneset overrepresentation analysis (ORA) using `Tier 1B` genes using all unique genes measured in the 4 datasets as background.
+We use [WebGestalt](https://doi.org/10.1093/nar/gkx356 "WebGestalt 2017: a more comprehensive, powerful, flexible and interactive gene set enrichment analysis toolkit") for ORA.
+The results of the pathway analysis are stored in `results/overrepresented_pathways_classifier_genes.tsv`.
+
 ## Computational Environment
 
 All processing and analysis scripts were performed using the conda environment specified in `environment.yml`.
@@ -57,11 +61,14 @@ The scripts are located in the `scripts/` folder and include:
 | `B.explore_correlations.py` | (A) Distribution of correlations across classifier genes and datasets (B) 95% and 99% threshold correlation dataframes in long format |
 | `C.threshold_venns.R` | Venn diagrams describing correlated genes across datasets for both thresholds and against all 29 classifier genes |
 | `D.get_overlap_genes.R` | A summary dataframe sorted by highest correlated genes with the highest support (99% threshold across all 4 datasets) |
-| `E.output_gmt_geneset_tiers.R` | A single `.gmt` file for use in downstream gene set enrichment-like analyses |
+| `E.gmt_genesets_pathway_analysis.R` | A single `.gmt` file for use in downstream gene set enrichment-like analyses |
+| `F.summarize_pathways.R` | A single table describing top 15 enriched gene ontology terms for each classifier gene |
 
-## Output DataFrame
+## Output
 
-The file `results/all_threshold_classifier_gene_correlations.tsv` contains 57,551 rows describing correlations of HGSC gene expression values against 29 nanostring classifier genes.
+### All thresholded gene correlations
+
+The file `results/all_threshold_classifier_gene_correlations.tsv` contains 57,551 rows describing correlations of HGSC gene expression values against 59 nanostring classifier genes.
 A description of the columns are:
 
 1. `classifier_gene` - The gene used in the nanostring subtype classifier
@@ -77,4 +84,23 @@ The file is sorted by percentage of datasets encountered, if the correlation exi
 Note that the scenario `(0, 1)` is possible for the 95% threshold and 99% threshold.
 This happens when a significant gene by gene correlation exists in a different number of datasets per threshold.
 
+### Gene set file
+
 This file is compiled into a `.gmt` file with confidence tiers.
+See above for more details on tiers.
+
+### Overrepresented Pathways
+
+The gene stores the top 15 enriched gene ontology (GO) biological process terms against correlated genesets for all classifier genes.
+A description of the columns:
+
+1. `classifier_gene` - The gene used in the nanostring subtype classifier
+2. `tier` - which geneset tier was used (in this case `tier-1B` was used)
+3. `geneset` - GO identifier
+4. `description` - GO term description
+5. `link` - a direct link to the GO term online information
+6. `PValue` - unadjusted P value for enrichment
+7. `FDR` - Benjamini-Hochberg adjusted P value
+8. `OverlapGene_UserID` - Which input genes were found in the given pathway
+
+The analyses is designed so that others may make different decisions on which genesets, tiers, or pathways to use.

--- a/7.Nanostring/README.md
+++ b/7.Nanostring/README.md
@@ -3,7 +3,7 @@
 **Gregory Way, Casey Greene, and Jennifer Doherty 2018**
 
 Previous research identified a sparse classifier of few genes that can classify High Grade Serous Ovarian Cancer (HGSC) subtypes.
-This classifier (Lasso) was selected to induce sparsity in the solutions so that the identified genes can be placed on a [nanostring](https://www.nanostring.com/) panel.
+This classifier (Random Forest) was used to find a sparse set of genes to be placed on a [nanostring](https://www.nanostring.com/) panel.
 
 Here, we test the correlation of these genes against all other genes measured across four HGSC gene expression datasets.
 The datasets include TCGA, Tothill, Yoshihara, and Mayo.
@@ -11,10 +11,28 @@ We use [curatedOvarianData](https://bioconductor.org/packages/release/data/exper
 
 ## Procedure
 
-We take the 29 nanostring genes and consider their gene expression vectors across the four datasets independently.
-We then take pairwise Pearson correlations of each of these 29 genes against **all** other genes for each dataset.
-Lastly, we consider the genes in the top 5% and top 1% of these correlations for all 29 genes for each dataset.
-The final output is a long data frame (`results/all_threshold_classifier_gene_correlations.tsv`) that stores the highest correlated genes against the nanostring classifier genes.
+We take the 59 nanostring genes and consider their gene expression vectors across the four datasets independently.
+We then take pairwise Pearson correlations of each of these 59 genes against **all** other genes for each dataset.
+Lastly, we consider the genes in the top 5% and top 1% of these correlations for all 59 genes for each dataset.
+The useful output is a long data frame (`results/all_threshold_classifier_gene_correlations.tsv`) that stores the highest correlated genes against the nanostring classifier genes.
+
+In addition, we output geneset files (`.gmt` format) under 4 different tiers of confidence.
+The file is located in `results/correlated_hgsc_classifier_genes.gmt`.
+The format of each line in this tab separated file is [classifier gene and confidence tier, correlated geneset (1, 2, ..., n)].
+The first gene in the correlated geneset is the classifier gene itself.
+
+| Confidence Tier | Description |
+| :-------------: | :---------- |
+| Tier 1A | Genes in 99% threshold correlations for all 4 datasets |
+| Tier 1B | Genes in 99% threshold correlations for all 3 datasets measured in (allows for a single dataset with missing measurements) |
+| Tier 2A | Genes in 95% threshold correlations for all 4 datasets |
+| Tier 2B | Genes in 95% threshold correlations for all 3 datasets measured in (allows for a single dataset with missing measurements) |
+| Tier 3 | Genes in 95% threshold correlations for 3/4 datasets (allows for a single dataset to not have correlation) |
+| Tier 4 | Genes in 95% threshold correlations for 2/4 datasets (allows for two datasets to not have correlations) |
+
+The tier system is built into the single `.gmt`.
+For high confident genesets use Tier 1A but at the cost of smaller sets.
+All correlations at the 95% or 99% percentile in at least 1 dataset are given in `results/all_threshold_classifier_gene_correlations`.
 
 ## Computational Environment
 
@@ -38,7 +56,8 @@ The scripts are located in the `scripts/` folder and include:
 | `A.get_correlation_output.R` | (A) Correlations between HGSC genes and subtype classifier genes (B) Missing classifier genes by dataset |
 | `B.explore_correlations.py` | (A) Distribution of correlations across classifier genes and datasets (B) 95% and 99% threshold correlation dataframes in long format |
 | `C.threshold_venns.R` | Venn diagrams describing correlated genes across datasets for both thresholds and against all 29 classifier genes |
-| `D.get_overlap_genes.R` | A final summary dataframe sorted by highest correlated genes with the highest support (99% threshold across all 4 datasets) |
+| `D.get_overlap_genes.R` | A summary dataframe sorted by highest correlated genes with the highest support (99% threshold across all 4 datasets) |
+| `E.output_gmt_geneset_tiers.R` | A single `.gmt` file for use in downstream gene set enrichment-like analyses |
 
 ## Output DataFrame
 
@@ -58,3 +77,4 @@ The file is sorted by percentage of datasets encountered, if the correlation exi
 Note that the scenario `(0, 1)` is possible for the 95% threshold and 99% threshold.
 This happens when a significant gene by gene correlation exists in a different number of datasets per threshold.
 
+This file is compiled into a `.gmt` file with confidence tiers.

--- a/7.Nanostring/README.md
+++ b/7.Nanostring/README.md
@@ -1,0 +1,60 @@
+# Gene Expression Correlations with Nanostring Subtype Classifier
+
+**Gregory Way and Casey Greene, 2018**
+
+Previous research identified a sparse classifier of few genes that can classify High Grade Serous Ovarian Cancer (HGSC) subtypes.
+This classifier (Lasso) was selected to induce sparsity in the solutions so that the identified genes can be placed on a [nanostring](https://www.nanostring.com/) panel.
+
+Here, we test the correlation of these genes against all other genes measured across four HGSC gene expression datasets.
+The datasets include TCGA, Tothill, Yoshihara, and Mayo.
+We use [curatedOvarianData](https://bioconductor.org/packages/release/data/experiment/html/curatedOvarianData.html) to access datasets.
+
+## Procedure
+
+We take the 29 nanostring genes and consider their gene expression vectors across the four datasets independently.
+We then take pairwise correlations of each of these 29 genes against **all** other genes for each dataset.
+Lastly, we consider the genes in the top 5% and top 1% of these correlations for all 29 genes for each dataset.
+The final output is a long data frame (`results/all_threshold_classifier_gene_correlations.tsv`) that stores the highest correlated genes against the nanostring classifier genes.
+
+## Computational Environment
+
+All processing and analysis scripts were performed using the conda environment specified in `environment.yml`.
+To build and activate this environment run:
+
+```bash
+# conda version 4.5.1
+conda env create --force --file environment.yml
+
+conda activate hgsc-nanostring
+```
+
+## Reproduce Pipeline
+
+Each of the scripts are designed to be executed sequentially.
+The scripts are located in the `scripts/` folder and include:
+
+| Script | Output |
+| :----- | :----- |
+| `A.get_correlation_output.R` | (A) Correlations between HGSC genes and subtype classifier genes (B) Missing classifier genes by dataset |
+| `B.explore_correlations.py` | (A) Distribution of correlations across classifier genes and datasets (B) 95% and 99% threshold correlation dataframes in long format |
+| `C.threshold_venns.R` | Venn diagrams describing correlated genes across datasets for both thresholds and against all 29 classifier genes |
+| `D.get_overlap_genes.R` | A final summary dataframe sorted by highest correlated genes with the highest support (99% threshold across all 4 datasets) |
+
+## Output DataFrame
+
+The file `results/all_threshold_classifier_gene_correlations.tsv` contains 57,551 rows describing correlations of HGSC gene expression values against 29 nanostring classifier genes.
+A description of the columns are:
+
+1. `classifier_gene` - The gene used in the nanostring subtype classifier
+2. `gene` - The gene compared against in the HGSC gene expression datasets
+3. `num_datasets` - How many datasets the nanostring classifier gene is measured in
+4. `percent_datasets` - Of `num_datasets` how many times is the gene correlation pair observed
+5. `min_gene_cor` - The minimum correlation observed for the gene by gene (for those not filtered by threshold)
+6. `max_gene_cor` - The maximum correlation observed for the gene by gene (for those not filtered by threshold)
+7. `95_threshold` - Indicator variable if the gene by gene correlation was observed in the top 5% of correlations
+8. `99_threshold` - Indicator variable if the gene by gene correlation was observed in the top 1% of correlations
+
+The file is sorted by percentage of datasets encountered, if the correlation exists in the 99% threshold, and then by maximum gene correlation.
+Note that the scenario `(0, 1)` is possible for the 95% threshold and 99% threshold.
+This happens when a significant gene by gene correlation exists in a different number of datasets per threshold.
+

--- a/7.Nanostring/environment.yml
+++ b/7.Nanostring/environment.yml
@@ -1,0 +1,20 @@
+name: hgsc-nanostring
+channels:
+- conda-forge
+- bioconda
+dependencies:
+- conda-forge::python=3.6
+- conda-forge::pandas=0.22.0
+- conda-forge::numpy=1.14.2
+- conda-forge::seaborn=0.8.1
+- conda-forge::jupyter=1.0.0
+- conda-forge::ipykernel=4.8.1
+- conda-forge::nb_conda_kernels=2.1.0
+- conda-forge::openpyxl=2.5.1
+- conda-forge::r-dplyr=0.7.4
+- conda-forge::r-tidyr=0.8.0
+- conda-forge::r-readr=1.1.1
+- conda-forge::r-ggplot2=2.2.1
+- conda-forge::r-venndiagram=1.6.18
+- conda-forge::r-irkernel=0.8.11
+- bioconda::bioconductor-curatedovariandata=1.16.0

--- a/7.Nanostring/scripts/A.get_correlation_output.R
+++ b/7.Nanostring/scripts/A.get_correlation_output.R
@@ -12,13 +12,19 @@
 
 library(dplyr)
 
-file <- file.path("data", "nanostring_classifier.tsv")
-classifier_df <- readr::read_tsv(file)
+file <- file.path("7.Nanostring", "data", "overallFreqs.csv")
+
+# Column rf stores the classifier genes - sort and take top 59
+top_n_genes <- 59
+classifier_df <- readr::read_csv(file) %>%
+  dplyr::arrange(desc(rfFreq)) %>%
+  dplyr::top_n(n = 59) %>%
+  dplyr::mutate(genes = toupper(genes))
 
 data <- c("TCGA_eset", "mayo.eset", "GSE32062.GPL6480_eset", "GSE9891_eset")
 
 # The script loads the ovarian cancer datasets
-load.ovca.path <- file.path("..", "1.DataInclusion", "Scripts", "Functions",
+load.ovca.path <- file.path("1.DataInclusion", "Scripts", "Functions",
                             "LoadOVCA_Data.R")
 source(load.ovca.path)
 
@@ -29,7 +35,7 @@ all_cor <- list()
 missing_info <- c()
 comp_idx <- 1
 # Loop through each unique gene in the classifier
-for (gene in unique(classifier_df$gene)) {
+for (gene in unique(classifier_df$genes)) {
 
   # Loop through each of the four datasets
   for (dataset in names(ExpData)) {
@@ -67,11 +73,12 @@ for (gene in unique(classifier_df$gene)) {
 # Output results
 # 1) Long correlation dataframe
 output_df <- dplyr::bind_rows(all_cor)
-file <- file.path("results", "classifier_correlation.tsv")
+file <- file.path("7.Nanostring", "results", "rf_classifier_correlation.tsv")
 readr::write_tsv(output_df, file)
 
 # 2) Missing gene by dataset information
+rownames(missing_info) <- 1:nrow(missing_info)
 missing_info <- as.data.frame(missing_info)
 colnames(missing_info) <- c("gene", "dataset")
-file <- file.path("results", "missing_gene_by_dataset.tsv")
+file <- file.path("7.Nanostring", "results", "rf_missing_gene_by_dataset.tsv")
 readr::write_tsv(missing_info, file)

--- a/7.Nanostring/scripts/A.get_correlation_output.R
+++ b/7.Nanostring/scripts/A.get_correlation_output.R
@@ -34,12 +34,14 @@ ExpData <- LoadOVCA_Data(datasets = data, genelist_subset = "None")
 all_cor <- list()
 missing_info <- c()
 comp_idx <- 1
+background_genes <- c()
 # Loop through each unique gene in the classifier
 for (gene in unique(classifier_df$genes)) {
 
   # Loop through each of the four datasets
   for (dataset in names(ExpData)) {
     exprs_df <- ExpData[[dataset]]
+    background_genes <- unique(c(background_genes, rownames(exprs_df)))
 
     # Make sure the gene exists in the dataset
     if (gene %in% rownames(exprs_df)) {
@@ -82,3 +84,8 @@ missing_info <- as.data.frame(missing_info)
 colnames(missing_info) <- c("gene", "dataset")
 file <- file.path("7.Nanostring", "results", "rf_missing_gene_by_dataset.tsv")
 readr::write_tsv(missing_info, file)
+
+# 3) Background genes
+a <- as.data.frame(background_genes[order(background_genes)])
+file <- file.path("7.Nanostring", "results", "background_genes.txt")
+readr::write_tsv(a, file, col_names = FALSE)

--- a/7.Nanostring/scripts/A.get_correlation_output.R
+++ b/7.Nanostring/scripts/A.get_correlation_output.R
@@ -18,7 +18,7 @@ file <- file.path("7.Nanostring", "data", "overallFreqs.csv")
 top_n_genes <- 59
 classifier_df <- readr::read_csv(file) %>%
   dplyr::arrange(desc(rfFreq)) %>%
-  dplyr::top_n(n = 59) %>%
+  dplyr::top_n(n = top_n_genes) %>%
   dplyr::mutate(genes = toupper(genes))
 
 data <- c("TCGA_eset", "mayo.eset", "GSE32062.GPL6480_eset", "GSE9891_eset")
@@ -41,6 +41,8 @@ for (gene in unique(classifier_df$genes)) {
   # Loop through each of the four datasets
   for (dataset in names(ExpData)) {
     exprs_df <- ExpData[[dataset]]
+    
+    # Track background genes for pathway analysis comparisons
     background_genes <- unique(c(background_genes, rownames(exprs_df)))
 
     # Make sure the gene exists in the dataset

--- a/7.Nanostring/scripts/A.get_correlation_output.R
+++ b/7.Nanostring/scripts/A.get_correlation_output.R
@@ -1,0 +1,77 @@
+# Nanostring Classifier Genes
+# Gregory Way 2018
+# 7.Nanostring/scripts/A.get_correlation_output.R
+#
+# Load in classifier and gene expression matrices and obtain correlation
+# between classifier genes and HGSC expressed genes across populations.
+# The datasets we use include TCGA, Mayo Clinic, Yoshihara, and Tothill
+#
+# Output:
+# 1) Correlation dataframe (long format)
+# 2) Gene by Dataset missing info table
+
+library(dplyr)
+
+file <- file.path("data", "nanostring_classifier.tsv")
+classifier_df <- readr::read_tsv(file)
+
+data <- c("TCGA_eset", "mayo.eset", "GSE32062.GPL6480_eset", "GSE9891_eset")
+
+# The script loads the ovarian cancer datasets
+load.ovca.path <- file.path("..", "1.DataInclusion", "Scripts", "Functions",
+                            "LoadOVCA_Data.R")
+source(load.ovca.path)
+
+# Use the LoadOVCA_Data function to read in the datasets subset by commongenes
+ExpData <- LoadOVCA_Data(datasets = data, genelist_subset = "None")
+
+all_cor <- list()
+missing_info <- c()
+comp_idx <- 1
+# Loop through each unique gene in the classifier
+for (gene in unique(classifier_df$gene)) {
+
+  # Loop through each of the four datasets
+  for (dataset in names(ExpData)) {
+    exprs_df <- ExpData[[dataset]]
+
+    # Make sure the gene exists in the dataset
+    if (gene %in% rownames(exprs_df)) {
+      # Subset gene expression vector of classifier gene
+      gene_vector <- exprs_df[gene, ]
+
+      # Obtain Pearson correlation of the gene vector and all other genes
+      gene_cor <- apply(exprs_df, 1, function(x) {
+        round(cor(x, gene_vector, method = "pearson"), 3)
+      })
+
+      # Convert the output to a dataframe that can be saved downstream
+      gene_cor <- dplyr::as.tbl(data.frame(gene_cor)) %>%
+        tibble::rownames_to_column(var = "gene")
+      gene_cor$classifier_gene <- gene
+      gene_cor$dataset <- dataset
+      
+      # Build results in iterative list
+      all_cor[[comp_idx]] <- gene_cor
+      comp_idx <- comp_idx + 1
+    }
+
+    # If the gene is not in the data frame store the missingness
+    else {
+      missing_gene_dataset <- c(gene, dataset)
+      missing_info <- rbind(missing_info, missing_gene_dataset)
+    }
+  }
+}
+
+# Output results
+# 1) Long correlation dataframe
+output_df <- dplyr::bind_rows(all_cor)
+file <- file.path("results", "classifier_correlation.tsv")
+readr::write_tsv(output_df, file)
+
+# 2) Missing gene by dataset information
+missing_info <- as.data.frame(missing_info)
+colnames(missing_info) <- c("gene", "dataset")
+file <- file.path("results", "missing_gene_by_dataset.tsv")
+readr::write_tsv(missing_info, file)

--- a/7.Nanostring/scripts/C.threshold_venns.R
+++ b/7.Nanostring/scripts/C.threshold_venns.R
@@ -104,18 +104,18 @@ output_all_venns <- function(df, output_dir, threshold) {
 }
 
 # Load thresholded dataframes
-base_file <- "results"
-fig_base <- "figures"
+base_file <- file.path("7.Nanostring", "results")
+fig_base <- file.path("7.Nanostring", "figures")
 
-file <- file.path(base_file, "high_99_quantile_correlated_genes.tsv")
+file <- file.path(base_file, "rf_high_99_quantile_correlated_genes.tsv")
 high_df <- readr::read_tsv(file)
 
-file <- file.path(base_file, "relaxed_95_quantile_correlated_genes.tsv")
+file <- file.path(base_file, "rf_relaxed_95_quantile_correlated_genes.tsv")
 relaxed_df <- readr::read_tsv(file)
 
 # Output all Venn Diagrams
-high_out <- file.path(fig_base, "venns", "high_threshold")
+high_out <- file.path(fig_base, "rf_venns", "high_threshold")
 output_all_venns(high_df, output_dir = high_out, threshold = "99")
 
-relaxed_out <- file.path(fig_base, "venns", "relaxed_threshold")
+relaxed_out <- file.path(fig_base, "rf_venns", "relaxed_threshold")
 output_all_venns(relaxed_df, output_dir = relaxed_out, threshold = "95")

--- a/7.Nanostring/scripts/C.threshold_venns.R
+++ b/7.Nanostring/scripts/C.threshold_venns.R
@@ -1,0 +1,121 @@
+# Nanostring Classifier Genes
+# Gregory Way 2018
+# 7.Nanostring/scripts/C.threshold_venns.R
+#
+# Obtain highly correlated genes (by 95% or 99% quantile) for each dataset
+# across all 29 genes. The four datasets are TCGA, Mayo, Yoshihara, and Tothill
+#
+# Output:
+# Two Venn Diagrams for Every Classifier Gene
+# The two venn diagrams will display overlap across the four datasets for the
+# two threshold levels across all genes
+
+library(dplyr)
+library(VennDiagram)
+futile.logger::flog.threshold(futile.logger::ERROR, name = "VennDiagramLogger")
+
+output_all_venns <- function(df, output_dir, threshold) {
+  # Get the overlap of genes correlating with classifier genes across datasets
+  #
+  # Arguments:
+  # df - Thresholded list of dataset gene correlations to classifier genes
+  # output_dir - the folder to save the results
+  # threshold - the percentile of filtered gene correlations
+  #
+  # Output:
+  # Venn Diagram figure of gene overlap
+
+  # Obtain list of lists that stores sets of correlated genes by classifier
+  # genes by dataset - this will be used for the Venn Diagram plotting
+  set_list <- list()
+  range_list <- list()
+
+  # Loop over each classifier gene
+  for (class_gene in unique(df$classifier_gene)) {
+    
+    # Subset the dataframe to each unique classifier gene
+    gene_subset <- df %>% dplyr::filter(classifier_gene == class_gene)
+    
+    # Initialize an empty list within the list named by the classifier gene
+    set_list[[class_gene]] <- list()
+    range_list[[class_gene]] <- list()
+
+    # Loop over each dataset
+    for (data in unique(gene_subset$dataset)) {
+      
+      # Subset the gene subset data frame to each unique dataset
+      dataset_gene_subset <- gene_subset %>% dplyr::filter(dataset == data)
+
+      # Store a set of correlated genes per dataset per classifier gene
+      set_list[[class_gene]][[data]] <- unique(dataset_gene_subset$gene)
+
+      # Store the range of the correlations
+      cor_range <- paste(round(range(dataset_gene_subset$gene_cor_abs), 2),
+                         collapse = " - ")
+      range_list[[class_gene]][[data]] <- cor_range
+    }
+  }
+
+  # Create a Venn Diagram for each gene - the circles will represent datasets
+  for (gene_name in names(set_list)) {
+
+    # Obtain the list for the current classifier gene
+    current_set_list <- set_list[[gene_name]]
+    current_range_list <- range_list[[gene_name]]
+
+    # Set the file name to output
+    file <- file.path(output_dir, paste0("venn_", gene_name, ".png"))
+    
+    # Which datasets are represented?
+    # Not all datasets have all classifier genes measured
+    datasets <- names(current_set_list)
+
+    # Set labels in Venn Diagram
+    yos <- paste0("Yoshihara\n", current_range_list[["GSE32062.GPL6480_eset"]])
+    tot <- paste0("Tothill\n", current_range_list[["GSE9891_eset"]])
+    tcga <- paste0("TCGA\n", current_range_list[["TCGA_eset"]])
+    mayo <- paste0("Mayo\n", current_range_list[["mayo.eset"]])
+
+    # Recode dataset eset nomenclature and fill color
+    category_names <- dplyr::recode(datasets,
+                                    "GSE32062.GPL6480_eset" = yos,
+                                    "GSE9891_eset" = tot,
+                                    "TCGA_eset" = tcga,
+                                    "mayo.eset" = mayo)
+    fill_colors <- dplyr::recode(datasets,
+                                 "GSE32062.GPL6480_eset" = "blue",
+                                 "GSE9891_eset" = "purple",
+                                 "TCGA_eset" = "red",
+                                 "mayo.eset" = "green")
+    
+    # Output the Venn Diagrams
+    VennDiagram::venn.diagram(
+      current_set_list,
+      main = paste0(gene_name, "\n", threshold, "% Threshold"),
+      main.cex = 1.5,
+      main.pos = c(0.5, 1.03),
+      category.names = category_names,
+      filename = file,
+      output = FALSE,
+      imagetype = "png",
+      fill = fill_colors,
+      lwd = 2)
+  }
+}
+
+# Load thresholded dataframes
+base_file <- "results"
+fig_base <- "figures"
+
+file <- file.path(base_file, "high_99_quantile_correlated_genes.tsv")
+high_df <- readr::read_tsv(file)
+
+file <- file.path(base_file, "relaxed_95_quantile_correlated_genes.tsv")
+relaxed_df <- readr::read_tsv(file)
+
+# Output all Venn Diagrams
+high_out <- file.path(fig_base, "venns", "high_threshold")
+output_all_venns(high_df, output_dir = high_out, threshold = "99")
+
+relaxed_out <- file.path(fig_base, "venns", "relaxed_threshold")
+output_all_venns(relaxed_df, output_dir = relaxed_out, threshold = "95")

--- a/7.Nanostring/scripts/D.get_overlap_genes.R
+++ b/7.Nanostring/scripts/D.get_overlap_genes.R
@@ -13,16 +13,16 @@
 
 library(dplyr)
 
-base_file <- "results"
+base_file <- file.path("7.Nanostring", "results")
 
 # Load thresholded dataframes
-file <- file.path(base_file, "high_99_quantile_correlated_genes.tsv")
+file <- file.path(base_file, "rf_high_99_quantile_correlated_genes.tsv")
 high_df <- readr::read_tsv(file)
-high_df$threshold <- "99_threshold"
+high_df$threshold <- "high_thresh"
 
-file <- file.path(base_file, "relaxed_95_quantile_correlated_genes.tsv")
+file <- file.path(base_file, "rf_relaxed_95_quantile_correlated_genes.tsv")
 relaxed_df <- readr::read_tsv(file)
-relaxed_df$threshold <- "95_threshold"
+relaxed_df$threshold <- "relaxed_thresh"
 
 # Not all classifier genes were measured by each platform - find out how many
 classifier_gene_per_dataset <- high_df %>% 
@@ -37,7 +37,7 @@ all_cor_df <- dplyr::bind_rows(high_df, relaxed_df) %>%
   dplyr::left_join(classifier_gene_per_dataset, by = 'classifier_gene')
 
 # Wrangle classifier data into interpretable output dataframe and output
-f <- file.path(base_file, "all_thresholded_classifier_gene_correlations.tsv")
+f <- file.path(base_file, "rf_all_thresholded_classifier_gene_correlations.tsv")
 output_cor_df <- all_cor_df %>%
   dplyr::group_by(classifier_gene, gene, threshold, num_datasets) %>% 
   dplyr::summarise(num_datasets_gene = n(),
@@ -51,6 +51,6 @@ output_cor_df <- all_cor_df %>%
                   value.var = "classifier_gene") %>%
   dplyr::as.tbl() %>%
   dplyr::arrange(desc(percent_datasets),
-                 desc(`99_threshold`),
+                 desc(high_thresh),
                  desc(max_gene_cor)) %>%
   readr::write_tsv(f)

--- a/7.Nanostring/scripts/D.get_overlap_genes.R
+++ b/7.Nanostring/scripts/D.get_overlap_genes.R
@@ -1,0 +1,56 @@
+# Nanostring Classifier Genes
+# Gregory Way 2018
+# 7.Nanostring/scripts/D.get_overlap_genes.R
+#
+# Determine gene candidates that are consistently strongly correlated with
+# classifier genes' expression across different HGSC datasets
+#
+# Output:
+# A single long dataframe consisting of classifier gene, correlated gene,
+# range of correlations across datasets, whether it exists in 99% or 95%
+# threshold, and how many and what percentage of datasets are included in the
+# overlap.
+
+library(dplyr)
+
+base_file <- "results"
+
+# Load thresholded dataframes
+file <- file.path(base_file, "high_99_quantile_correlated_genes.tsv")
+high_df <- readr::read_tsv(file)
+high_df$threshold <- "99_threshold"
+
+file <- file.path(base_file, "relaxed_95_quantile_correlated_genes.tsv")
+relaxed_df <- readr::read_tsv(file)
+relaxed_df$threshold <- "95_threshold"
+
+# Not all classifier genes were measured by each platform - find out how many
+classifier_gene_per_dataset <- high_df %>% 
+  dplyr::group_by(classifier_gene, dataset) %>% 
+  dplyr::summarise(num_genes = n()) %>% 
+  dplyr::mutate(num_datasets = n()) %>% 
+  dplyr::select(classifier_gene, num_datasets) %>% 
+  dplyr::distinct()
+
+# Combine datasets
+all_cor_df <- dplyr::bind_rows(high_df, relaxed_df) %>% 
+  dplyr::left_join(classifier_gene_per_dataset, by = 'classifier_gene')
+
+# Wrangle classifier data into interpretable output dataframe and output
+f <- file.path(base_file, "all_thresholded_classifier_gene_correlations.tsv")
+output_cor_df <- all_cor_df %>%
+  dplyr::group_by(classifier_gene, gene, threshold, num_datasets) %>% 
+  dplyr::summarise(num_datasets_gene = n(),
+                   min_gene_cor = min(gene_cor),
+                   max_gene_cor = max(gene_cor)) %>%
+  dplyr::mutate(percent_datasets = (num_datasets_gene / num_datasets)) %>% 
+  reshape2::dcast(classifier_gene + gene + num_datasets + percent_datasets +
+                    min_gene_cor + max_gene_cor ~
+                    threshold,
+                  fun.aggregate = function(x) length(x),
+                  value.var = "classifier_gene") %>%
+  dplyr::as.tbl() %>%
+  dplyr::arrange(desc(percent_datasets),
+                 desc(`99_threshold`),
+                 desc(max_gene_cor)) %>%
+  readr::write_tsv(f)

--- a/7.Nanostring/scripts/E.gmt_genesets_pathway_analysis.R
+++ b/7.Nanostring/scripts/E.gmt_genesets_pathway_analysis.R
@@ -45,8 +45,9 @@ compile_gmt <- function(tier_matrix, tier_name) {
   return(geneset_list)
 }
 
-base <- file.path("7.Nanostring", "results")
-f <- file.path(base, "rf_all_thresholded_classifier_gene_correlations.tsv")
+results_dir <- file.path("7.Nanostring", "results")
+f <- file.path(results_dir,
+               "rf_all_thresholded_classifier_gene_correlations.tsv")
 df <- readr::read_tsv(f,
                       col_types = list(.default = "c",
                                        num_datasets = readr::col_integer(),
@@ -116,7 +117,7 @@ big_gmt_list <- c(tier_1a_gmt, tier_1b_gmt, tier_2a_gmt, tier_2b_gmt,
                    tier_3_gmt, tier_4_gmt)
 
 # Write contents of gmt list into file line by line
-gmt_file <- file.path(base, "correlated_hgsc_classifier_genes.gmt")
+gmt_file <- file.path(results_dir, "correlated_hgsc_classifier_genes.gmt")
 for (gmt in big_gmt_list) {
   write.table(t(gmt), file = gmt_file, sep = "\t", append = TRUE,
               col.names = FALSE, row.names = FALSE, quote = FALSE)

--- a/7.Nanostring/scripts/E.output_gmt_geneset_tiers.R
+++ b/7.Nanostring/scripts/E.output_gmt_geneset_tiers.R
@@ -9,8 +9,8 @@
 # Tier 1B - Genes in 99% threshold correlations for all 3 datasets measured in
 # Tier 2A - Genes in 95% threshold correlations for all 4 datasets
 # Tier 2B - Genes in 95% threshold correlations for all 3 datasets measured in
-# Tier 3 - Genes in 99% threshold correlations for 3/4 datasets
-# Tier 4 - Genes in 95% threshold correlations for 3/4 datasets
+# Tier 3 - Genes in 95% threshold correlations for 3/4 datasets
+# Tier 4 - Genes in 95% threshold correlations for 2/4 datasets
 #
 # Output:
 # A single Gene Matrix Transposed (.gmt) file describing gene sets of
@@ -72,7 +72,8 @@ tier_1b  <- df %>%
 
 # Tier 2a - Exactly as tier 1a but includes genes in the 95% percentile
 tier_2a  <- df %>%
-  dplyr::filter(num_datasets == 4, percent_datasets == 1) %>%
+  dplyr::filter(relaxed_thresh == 1, num_datasets == 4,
+                percent_datasets == 1) %>%
   dplyr::group_by(classifier_gene) %>%
   reshape2::acast(classifier_gene ~ gene, value.var = "relaxed_thresh",
                   fill = 0)

--- a/7.Nanostring/scripts/E.output_gmt_geneset_tiers.R
+++ b/7.Nanostring/scripts/E.output_gmt_geneset_tiers.R
@@ -77,7 +77,7 @@ tier_2a  <- df %>%
   dplyr::group_by(classifier_gene) %>%
   reshape2::acast(classifier_gene ~ gene, value.var = "relaxed_thresh",
                   fill = 0)
-# Tier 2a - Exactly as tier 1b but includes genes in the 95% percentile
+# Tier 2b - Exactly as tier 1b but includes genes in the 95% percentile
 tier_2b  <- df %>%
   dplyr::filter(relaxed_thresh == 1, num_datasets >= 3,
                 percent_datasets == 1) %>%

--- a/7.Nanostring/scripts/E.output_gmt_geneset_tiers.R
+++ b/7.Nanostring/scripts/E.output_gmt_geneset_tiers.R
@@ -1,0 +1,119 @@
+# Nanostring Classifier Genes
+# Gregory Way 2018
+# 7.Nanostring/scripts/E.output_gmt_geneset_tiers.R
+#
+# Define a tier system based on confidence of correlation between classifier
+# genes and HGSC gene expression. The tier system is as follows:
+#
+# Tier 1A - Genes in 99% threshold correlations for all 4 datasets
+# Tier 1B - Genes in 99% threshold correlations for all 3 datasets measured in
+# Tier 2A - Genes in 95% threshold correlations for all 4 datasets
+# Tier 2B - Genes in 95% threshold correlations for all 3 datasets measured in
+# Tier 3 - Genes in 99% threshold correlations for 3/4 datasets
+# Tier 4 - Genes in 95% threshold correlations for 3/4 datasets
+#
+# Output:
+# A single Gene Matrix Transposed (.gmt) file describing gene sets of
+# correlated genes against random forest classifier genes
+
+library(dplyr)
+
+compile_gmt <- function(tier_matrix, tier_name) {
+  # Extract geneset in gmt format based on input matrix
+  #
+  # Arguments
+  # tier_matrix - binary matrix
+  #               classifier genes (rows) by correlated genes (columns)
+  # tier_name - the name of the tier to store in gmt gene set names
+  #
+  # Output:
+  # a list of genesets
+  #    the first element of the geneset is the classifier gene followed by the
+  #    correlated geneset
+  
+  geneset_list <- list()
+  for (geneset_idx in 1:nrow(tier_matrix)) {
+    class_gene <- rownames(tier_matrix)[geneset_idx]
+    geneset_name <- paste(class_gene, tier_name, sep = "_")
+    geneset <- tier_matrix[geneset_idx, ]
+    geneset <- names(geneset[geneset >= 1])
+    geneset_list[[geneset_name]] <- c(geneset_name, class_gene, geneset)
+  }
+  return(geneset_list)
+}
+
+base <- file.path("7.Nanostring", "results")
+f <- file.path(base, "rf_all_thresholded_classifier_gene_correlations.tsv")
+df <- readr::read_tsv(f,
+                      col_types = list(.default = "c",
+                                       num_datasets = readr::col_integer(),
+                                       percent_datasets = readr::col_double(),
+                                       min_gene_cor = readr::col_double(),
+                                       max_gene_cor = readr::col_double(),
+                                       high_thresh = readr::col_integer(),
+                                       relaxed_thresh = readr::col_integer()))
+
+# Collect Gene Set Tiers
+# Tier 1a - is the strictest cutoff for correlated genesets -
+# Genes were correlated in 4/4 datasets in the 99% percentile of correlations
+tier_1a  <- df %>%
+  dplyr::filter(high_thresh == 1, num_datasets == 4, percent_datasets == 1) %>%
+  dplyr::group_by(classifier_gene) %>%
+  reshape2::acast(classifier_gene ~ gene, value.var = "high_thresh", fill = 0)
+
+# Tier 1b - is the second strictest cutoff
+# Genes were correlated in at least 3 datasets but 100% of the time in the
+# 99% percentile of correlations
+# This includes the situation where a gene was not measured in one dataset
+tier_1b  <- df %>%
+  dplyr::filter(high_thresh == 1, num_datasets >= 3, percent_datasets == 1) %>%
+  dplyr::group_by(classifier_gene) %>%
+  reshape2::acast(classifier_gene ~ gene, value.var = "high_thresh", fill = 0)
+
+# Tier 2a - Exactly as tier 1a but includes genes in the 95% percentile
+tier_2a  <- df %>%
+  dplyr::filter(num_datasets == 4, percent_datasets == 1) %>%
+  dplyr::group_by(classifier_gene) %>%
+  reshape2::acast(classifier_gene ~ gene, value.var = "relaxed_thresh",
+                  fill = 0)
+# Tier 2a - Exactly as tier 1b but includes genes in the 95% percentile
+tier_2b  <- df %>%
+  dplyr::filter(relaxed_thresh == 1, num_datasets >= 3,
+                percent_datasets == 1) %>%
+  dplyr::group_by(classifier_gene) %>%
+  reshape2::acast(classifier_gene ~ gene, value.var = "relaxed_thresh",
+                  fill = 0)
+
+# Tier 3 - 95% percentile genes that is correlated in 3/4 datasets
+tier_3  <- df %>%
+  dplyr::filter(relaxed_thresh == 1, num_datasets >= 3,
+                percent_datasets >= 0.75) %>%
+  dplyr::group_by(classifier_gene) %>%
+  reshape2::acast(classifier_gene ~ gene, value.var = "relaxed_thresh",
+                  fill = 0)
+
+# Tier 4 - 95% percentile genes that is correlated in 2/4 datasets
+tier_4  <- df %>%
+  dplyr::filter(relaxed_thresh == 1, num_datasets >= 2,
+                percent_datasets >= 0.50) %>%
+  dplyr::group_by(classifier_gene) %>%
+  reshape2::acast(classifier_gene ~ gene, value.var = "relaxed_thresh",
+                  fill = 0)
+
+# Create gmt geneset lists
+tier_1a_gmt <- compile_gmt(tier_matrix = tier_1a, tier_name = "tier-1A")
+tier_1b_gmt <- compile_gmt(tier_matrix = tier_1b, tier_name = "tier-1B")
+tier_2a_gmt <- compile_gmt(tier_matrix = tier_2a, tier_name = "tier-2A")
+tier_2b_gmt <- compile_gmt(tier_matrix = tier_2b, tier_name = "tier-2B")
+tier_3_gmt <- compile_gmt(tier_matrix = tier_3, tier_name = "tier-3")
+tier_4_gmt <- compile_gmt(tier_matrix = tier_4, tier_name = "tier-4")
+
+big_gmt_list <- c(tier_1a_gmt, tier_1b_gmt, tier_2a_gmt, tier_2b_gmt,
+                   tier_3_gmt, tier_4_gmt)
+
+# Write contents of gmt list into file line by line
+gmt_file <- file.path(base, "correlated_hgsc_classifier_genes.gmt")
+for (gmt in big_gmt_list) {
+  write.table(t(gmt), file = gmt_file, sep = "\t", append = TRUE,
+              col.names = FALSE, row.names = FALSE, quote = FALSE)
+}


### PR DESCRIPTION
This Pull Request adds the code to reproduce the results of the Nanostring subtype classifier module.

Note that **not all scripts** are included. I do not include scripts that would compromise the identity of the actual genes. The script and notebook are derived from `B.explore_correlations.py`. This will be added upon publication. All figures and results are also **not** added for the same reason.