### PR TITLE
Adding Custom Installation of WebGestaltR

### DIFF
--- a/7.Nanostring/run_analysis.sh
+++ b/7.Nanostring/run_analysis.sh
@@ -5,6 +5,12 @@
 #
 # NOTE: all scripts should be run from the top `hgsc_subtypes` directory
 
+set -o errexit
+exec &>7.Nanostring/nanostring_analysis.out
+
+# Step 0 - Install package inside conda environment
+Rscript 7.Nanostring/scripts/0.install_custom.R
+
 # Step 1 - Obtain the correlation output files
 Rscript 7.Nanostring/scripts/A.get_correlation_output.R
 

--- a/7.Nanostring/scripts/0.install_custom.R
+++ b/7.Nanostring/scripts/0.install_custom.R
@@ -1,0 +1,5 @@
+# Install WebGestalt - perform within conda environment
+# i.e. after running `conda activate nanostring-classifier`
+
+install.packages("WebGestaltR", repos = "http://cran.us.r-project.org")
+


### PR DESCRIPTION
WebgestaltR cannot be added to conda environment - this is a workaround.

I also add line 8 to the analysis script that will cause the script to exit if there are any errors, and line 9 that will push stdout to a file. 

Make sure the conda environment is activated before running `bash 7. Nanostring/run_analysis.sh`
